### PR TITLE
Fix nightly build

### DIFF
--- a/src/Util/PHP/Template/TestCaseMethod.tpl.dist
+++ b/src/Util/PHP/Template/TestCaseMethod.tpl.dist
@@ -78,7 +78,7 @@ if ('' !== $configurationFilePath) {
     unset($configuration);
 }
 
-function __phpunit_error_handler($errno, $errstr, $errfile, $errline, $errcontext)
+function __phpunit_error_handler($errno, $errstr, $errfile, $errline, $errcontext = null)
 {
    return true;
 }

--- a/tests/Framework/ConstraintTest.php
+++ b/tests/Framework/ConstraintTest.php
@@ -1377,7 +1377,9 @@ EOF
 
         $this->assertTrue($constraint->evaluate($resource, '', true));
 
-        @fclose($resource);
+        if (is_resource($resource)) {
+            fclose($resource);
+        }
     }
 
     /**

--- a/tests/Regression/Trac/578.phpt
+++ b/tests/Regression/Trac/578.phpt
@@ -1,5 +1,8 @@
 --TEST--
 #578: Double printing of trace line for exceptions from notices and warnings
+--SKIPIF--
+<?php
+if (PHP_VERSION_ID >= 80000) die('Skipped: Error message changed in PHP8 or later'); ?>
 --FILE--
 <?php
 $_SERVER['argv'][1] = '--no-configuration';


### PR DESCRIPTION
- Fix closed resources
- Skip PHP8 or later
- Fix deprecated features in PHP 7.2.0 of `set_error_handler()`
  - see https://www.php.net/manual/en/function.set-error-handler.php