### PR TITLE
PHP8-RC1 support

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -966,10 +966,11 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
             $this->fail($e->getMessage());
         }
 
+        $testArguments = array_merge($this->data, $this->dependencyInput);
         try {
             $testResult = $method->invokeArgs(
                 $this,
-                array_merge($this->data, $this->dependencyInput)
+                array_values($testArguments)
             );
         } catch (Throwable $_e) {
             $e = $_e;

--- a/src/Util/Configuration.php
+++ b/src/Util/Configuration.php
@@ -162,7 +162,7 @@ class PHPUnit_Util_Configuration
     /**
      * @since  Method available since Release 3.4.0
      */
-    final private function __clone()
+    private function __clone()
     {
     }
 

--- a/tests/Framework/Constraint/JsonMatches/ErrorMessageProviderTest.php
+++ b/tests/Framework/Constraint/JsonMatches/ErrorMessageProviderTest.php
@@ -42,9 +42,13 @@ class Framework_Constraint_JsonMatches_ErrorMessageProviderTest extends PHPUnit_
 
     public static function determineJsonErrorDataprovider()
     {
+        $unknown_error = null;
+        if (PHP_VERSION_ID >= 80000) {
+            $unknown_error = 'Unknown error';
+        }
         return array(
             'JSON_ERROR_NONE'  => array(
-                null, 'json_error_none', ''
+                $unknown_error, 'json_error_none', ''
             ),
             'JSON_ERROR_DEPTH' => array(
                 'Maximum stack depth exceeded', JSON_ERROR_DEPTH, ''

--- a/tests/Framework/ConstraintTest.php
+++ b/tests/Framework/ConstraintTest.php
@@ -2882,7 +2882,12 @@ EOF
         // Default case.
         $constraint = new PHPUnit_Framework_Constraint_TraversableContains('foo');
 
-        $this->assertTrue($constraint->evaluate(array(0), '', true));
+        if (PHP_VERSION_ID >= 80000) {
+            // see https://wiki.php.net/rfc/string_to_number_comparison
+            $this->assertFalse($constraint->evaluate(array(0), '', true));
+        } else {
+            $this->assertTrue($constraint->evaluate(array(0), '', true));
+        }
         $this->assertTrue($constraint->evaluate(array(true), '', true));
     }
 

--- a/tests/Regression/GitHub/873-php7.phpt
+++ b/tests/Regression/GitHub/873-php7.phpt
@@ -2,7 +2,7 @@
 GH-873: PHPUnit suppresses exceptions thrown outside of test case function
 --SKIPIF--
 <?php
-if (PHP_MAJOR_VERSION < 7) {
+if (PHP_MAJOR_VERSION != 7) {
     print 'skip: PHP 7 is required';
 }
 ?>

--- a/tests/TextUI/fatal-isolation.phpt
+++ b/tests/TextUI/fatal-isolation.phpt
@@ -1,5 +1,8 @@
 --TEST--
 phpunit FatalTest --process-isolation ../_files/FatalTest.php
+--SKIPIF--
+<?php
+if (PHP_VERSION_ID >= 80000) die('Skipped: xdebug_disable() is obsolete in PHP8 or later'); ?>
 --FILE--
 <?php
 $_SERVER['argv'][1] = '--no-configuration';

--- a/tests/_files/FatalTest.php
+++ b/tests/_files/FatalTest.php
@@ -4,7 +4,7 @@ class FatalTest extends PHPUnit_Framework_TestCase
 {
     public function testFatalError()
     {
-        if (extension_loaded('xdebug')) {
+        if (extension_loaded('xdebug') && function_exists('xdebug_disable')) {
             xdebug_disable();
         }
 

--- a/tests/_files/Singleton.php
+++ b/tests/_files/Singleton.php
@@ -7,7 +7,7 @@ class Singleton
     {
     }
 
-    final private function __clone()
+    private function __clone()
     {
     }
 


### PR DESCRIPTION
- Fix warnings below:
    > PHP Warning:  Private methods cannot be final as they are never overridden by other classes
- Fix ReflectionException
- Error message changed in PHP8 or later
- string to number comparison changed in PHP8 or later
   - see https://wiki.php.net/rfc/string_to_number_comparison